### PR TITLE
Update docs - Arbitrum

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -8,3 +8,5 @@ sidebar_label: Audits
 Trader Joe V2: Liquidity Book received the following audits:
 
 - [ABDK](https://github.com/abdk-consulting/audits/blob/main/traderjoe/ABDK_TraderJoe_TraderJoe_v_2_0.pdf)
+
+- [Code4rena](https://code4rena.com/reports/2022-10-traderjoe/)

--- a/docs/deployment-addresses/arbitrum.md
+++ b/docs/deployment-addresses/arbitrum.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 2
+sidebar_label: Arbitrum One
+---
+
+# Arbitrum One
+
+All the Joe V2 contracts have been deployed on the Arbitrum One:
+
+| Contract  |                                                       Address                                                        |
+| :-------: | :------------------------------------------------------------------------------------------------------------------: |
+| LBFactory | [0x1886D09C9Ade0c5DB822D85D21678Db67B6c2982](https://arbiscan.io/address/0x1886D09C9Ade0c5DB822D85D21678Db67B6c2982) |
+| LBRouter  | [0x7BFd7192E76D950832c77BB412aaE841049D8D9B](https://arbiscan.io/address/0x7BFd7192E76D950832c77BB412aaE841049D8D9B) |
+| LBQuoter  | [0x7f281f22eDB332807A039073a7F34A4A215bE89e](https://arbiscan.io/address/0x7f281f22eDB332807A039073a7F34A4A215bE89e) |
+
+You can also find Joe V1 contracts:
+
+|  Contract  |                                                       Address                                                        |
+| :--------: | :------------------------------------------------------------------------------------------------------------------: |
+| Factory V1 | [0xaE4EC9901c3076D0DdBe76A520F9E90a6227aCB7](https://arbiscan.io/address/0xaE4EC9901c3076D0DdBe76A520F9E90a6227aCB7) |
+| Router V1  | [0xbeE5c10Cf6E4F68f831E11C1D9E59B43560B3642](https://arbiscan.io/address/0xbeE5c10Cf6E4F68f831E11C1D9E59B43560B3642) |

--- a/docs/deployment-addresses/arbitrum_goerli.md
+++ b/docs/deployment-addresses/arbitrum_goerli.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 3
+sidebar_label: Arbitrum Goerli
+---
+
+# Arbitrum Goerli
+
+All the Joe V2 contracts have been deployed on the Arbitrum Goerli:
+
+| Contract  |                                                           Address                                                           |
+| :-------: | :-------------------------------------------------------------------------------------------------------------------------: |
+| LBFactory | [0xC8Af41e49e2C03eA14706C7aa9cEE60454bc5c03](https://goerli.arbiscan.io/address/0xC8Af41e49e2C03eA14706C7aa9cEE60454bc5c03) |
+| LBRouter  | [0x6E9603f925FB5A74f7321f51499d9633c1252893](https://goerli.arbiscan.io/address/0x6E9603f925FB5A74f7321f51499d9633c1252893) |
+| LBQuoter  | [0x42B0D9a10ee9B96a599C98a618205d0288636762](https://goerli.arbiscan.io/address/0x42B0D9a10ee9B96a599C98a618205d0288636762) |
+
+You can also find Joe V1 contracts:
+
+|  Contract  |                                                           Address                                                           |
+| :--------: | :-------------------------------------------------------------------------------------------------------------------------: |
+| Factory V1 | [0x1886D09C9Ade0c5DB822D85D21678Db67B6c2982](https://goerli.arbiscan.io/address/0x1886D09C9Ade0c5DB822D85D21678Db67B6c2982) |
+| Router V1  | [0x454206AD825cAfaE03c9581014AF6b74f7D53713](https://goerli.arbiscan.io/address/0x454206AD825cAfaE03c9581014AF6b74f7D53713) |

--- a/docs/deployment-addresses/fuji.md
+++ b/docs/deployment-addresses/fuji.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-sidebar_label: Fuji
+sidebar_label: Fuji Testnet
 ---
 
 # Fuji

--- a/docs/deployment-addresses/fuji.md
+++ b/docs/deployment-addresses/fuji.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 sidebar_label: Fuji
 ---
 
@@ -23,10 +23,6 @@ You can also find Joe V1 contracts:
 ## Faucets
 
 [AVAX Faucet](https://faucet.avax.network/) is official faucet by Avalanche Foundation. (Please note that their USDC, USDT tokens are not compatible with Trader Joe testnet.)
-
-You may also request testnet tokens (AVAX, USDC, USDT) from our faucet - head to Trader Joe Discord [here](https://discord.gg/traderjoe), and use command `!faucet <your-address>` on channel `#lb-testnet`. Please note: You can fund your address only once per 24h (command has a 60 second global delay).
-
-Using our faucet directly on-chain is disabled.
 
 ## ERC20 Tokens
 

--- a/docs/guides/manage-a-liquidity-position.md
+++ b/docs/guides/manage-a-liquidity-position.md
@@ -89,7 +89,7 @@ The number of parameters are quite extensive. Here are a few pointers to underst
 - `distributionX` (or `distributionY`) is the percentages of `amountX` (or `amountY`) you want to add to each bin.
   - Sum of all values should be less than or equal to 1. If less than, the remaining is refunded back to the user.
   - Trying to add X to a bin below the active bin or Y to a bin above the active bin will cause a revert.
-- Maximum number of bins, that can be populated at the same time is around `51` due to Avalanche C-chain block gas limit (`8M`). Multiple transactions can be used to add liquidity to more bins.
+- Maximum number of bins, that can be populated at the same time is around `80` on Avalanche C-chain due to block gas limit (`8M`). Multiple transactions can be used to add liquidity to more bins.
 
 ### Code Example
 

--- a/docs/subgraphs/arbitrum.md
+++ b/docs/subgraphs/arbitrum.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 2
+sidebar_label: Arbitrum One
+---
+
+# Arbitrum One
+
+Public subgraphs deployed on Arbitrum One mainnet:
+
+| Subgraph |                                    URL                                     |
+| :------: | :------------------------------------------------------------------------: |
+|  Joe-v2  | https://thegraph.com/hosted-service/subgraph/traderjoe-xyz/joe-v2-arbitrum |


### PR DESCRIPTION
In this PR I add:
- Arbitrum One/Goerli deployment addresses and Subgraph
- c4a audit
- change max number of bins on Avax